### PR TITLE
Run shell commands with -x when -x arg

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -105,6 +105,21 @@ func Run(c *config.Config, name string, args []string) {
 	}
 }
 
+// Run the task with xtrace
+func RunTrace(c *config.Config, name string, args []string) {
+	task, ok := c.Tasks[name]
+	if !ok {
+		Fatalf("undefined task %q", name)
+	}
+
+	task.LookupPath = filepath.Dir(c.File)
+
+	err := task.RunTrace(args)
+	if err != nil {
+		Fatalf("error: %s", err)
+	}
+}
+
 // Fatalf writes to stderr and exits.
 func Fatalf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "\n  %s\n\n", fmt.Sprintf(msg, args...))

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 const usage = `
   Usage:
     robo [--config file]
-    robo <task> [<arg>...] [--config file]
+    robo [--xtrace] <task> [<arg>...] [--config file]
     robo help [<task>] [--config file]
     robo variables [--config file]
     robo -h | --help
@@ -30,6 +30,7 @@ const usage = `
 
   Options:
     -c, --config file   config file to load
+    -x, --xtrace        set xtrace when running scripts or commands
     -h, --help          output help information
     -v, --version       output version
 
@@ -96,7 +97,12 @@ func main() {
 					Set("args", arguments),
 			})
 
-			cli.Run(conf, name, arguments)
+			xtrace, ok := args["--xtrace"].(bool)
+			if xtrace && ok {
+				cli.RunTrace(conf, name, arguments)
+			} else {
+				cli.Run(conf, name, arguments)
+			}
 		} else {
 			cli.List(conf)
 		}

--- a/task/task.go
+++ b/task/task.go
@@ -25,6 +25,13 @@ type Task struct {
 	Exec       string
 	Usage      string
 	Examples   []*Example
+	Trace      bool
+}
+
+// Run the task with xtrace shell option
+func (t *Task) RunTrace(args []string) error {
+	t.Trace = true
+	return t.Run(args)
 }
 
 // Run the task with `args`.
@@ -48,6 +55,9 @@ func (t *Task) Run(args []string) error {
 func (t *Task) RunScript(args []string) error {
 	path := filepath.Join(t.LookupPath, t.Script)
 	args = append([]string{path}, args...)
+	if t.Trace {
+		args = append([]string{"-x"}, args...)
+	}
 	cmd := exec.Command("sh", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -58,6 +68,9 @@ func (t *Task) RunScript(args []string) error {
 // RunCommand runs the `command` via the shell.
 func (t *Task) RunCommand(args []string) error {
 	args = append([]string{"-c", t.Command, "sh"}, args...)
+	if t.Trace {
+		args = append([]string{"-x"}, args...)
+	}
 	cmd := exec.Command("sh", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This goofy hack adds an `--xtrace` flag that launches all shell commands/scripts with `sh -x` to enable tracing. Useful when the scripts themselves have anemic logging or error handling.

I think it also probably has the side effect of allowing a `trace` field in the config, but I haven't tested.

I'm not sure whether this is a good idea. Mostly just needed to get it out of my head.